### PR TITLE
use local variable instead of redundant call.

### DIFF
--- a/Chapter4/DataStore.idr
+++ b/Chapter4/DataStore.idr
@@ -40,7 +40,7 @@ getEntry pos store
     = let store_items = items store in
           case integerToFin pos (size store) of
                Nothing => Just ("Out of range\n", store)
-               Just id => Just (index id (items store) ++ "\n", store)
+               Just id => Just (index id store_items ++ "\n", store)
 
 processInput : DataStore -> String -> Maybe (String, DataStore)
 processInput store input


### PR DESCRIPTION
* the local variable `store_items` is first introduced on p 119 (3)
* it is used in the call to `index` on p 120 (6)
* but it disappears in the complete listing on p 121 in the definition of `getEntry` rendering the local variable unused.

The proposed patch makes the two versions of the function consistent.

Also: thank you very much for a great book, really enjoying it so far!