### PR TITLE
Chapter 15: no need to have Loop in simple Process

### DIFF
--- a/Chapter15/Process.idr
+++ b/Chapter15/Process.idr
@@ -8,7 +8,6 @@ data Process : Type -> Type where
      Request : MessagePID -> Message -> Process (Maybe Nat)
      Respond : ((msg : Message) -> Process Nat) -> Process (Maybe Message)
      Spawn : Process () -> Process (Maybe MessagePID)
-     Loop : Inf (Process a) -> Process a
 
      Action : IO a -> Process a
      Pure : a -> Process a
@@ -34,7 +33,6 @@ run (Respond calc)
 run (Spawn proc) = do Just pid <- spawn (run proc)
                            | Nothing => pure Nothing
                       pure (Just (MkMessage pid))
-run (Loop action) = run action
 run (Action act) = act
 run (Pure val) = pure val
 run (act >>= next) = do x <- run act


### PR DESCRIPTION
Since `procAdder` described in section 15.2.1 is not total, there is no need to have `Loop` constructor in `Process`. 

`Loop` is introduced in section 15.2.2 to make `procAdder` total, which is covered by `ProcessLoop.idr`.
