### PR TITLE
Fix type in `unsafeRecv` call

### DIFF
--- a/Chapter15/AdderChannel.idr
+++ b/Chapter15/AdderChannel.idr
@@ -17,6 +17,6 @@ main = do Just adder_id <- spawn adder
           Just chan <- connect adder_id
                | Nothing => putStrLn "Connection failed"
           ok <- unsafeSend chan (Add 2 3)
-          Just answer <- unsafeRecv String chan
+          Just answer <- unsafeRecv Nat chan
                | Nothing => putStrLn "Send failed"
           printLn answer


### PR DESCRIPTION
The message returned from `adder` is a `Nat` but `unsafeRecv` is told to expect a `String`. This will segfault when run.